### PR TITLE
Coverage badge wasn't looking at master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Jolly Advisor
 
 [![Build Status](https://travis-ci.org/hacsoc/the_jolly_advisor.svg?branch=master)](https://travis-ci.org/hacsoc/the_jolly_advisor)
-[![Coverage Status](https://coveralls.io/repos/hacsoc/the_jolly_advisor/badge.svg)](https://coveralls.io/r/hacsoc/the_jolly_advisor)
+[![Coverage Status](https://coveralls.io/repos/hacsoc/the_jolly_advisor/badge.svg?branch=master)](https://coveralls.io/r/hacsoc/the_jolly_advisor)
 
 ## Development
 


### PR DESCRIPTION
Coverage was unknown in the readme because url wasn't specified to master branch. oops.