### PR TITLE
fixes search bug found by @cgutman.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,8 +1,8 @@
 class Course < ActiveRecord::Base
   has_many :course_instances, dependent: :destroy
 
-  scope :search, ->(q) { where("concat(lower(department), course_number) like ?
-                               OR lower(title) like ?",
+  scope :search, ->(q) { where("concat(lower(courses.department), courses.course_number) like ?
+                               OR lower(courses.title) like ?",
                                "%#{q.to_s.downcase.gsub(/\s+/,'')}%", "%#{q.to_s.downcase}%") }
 
   # Get all prereq info from the database.


### PR DESCRIPTION
problem was when we query on both courses and professors, the department
column is ambiguous because it's defined on both tables. so I just added
the courses table to fully-qualify everything the `Course.search` method
was using.