### PR TITLE
temporarily fixes #91.

### DIFF
--- a/app/views/wishlist/index.html.haml
+++ b/app/views/wishlist/index.html.haml
@@ -22,7 +22,7 @@
             - @wishlist.each do |item|
               %tr
                 %td= link_to item.course, item.course
-                %td= item.course.schedulable? ? "Yes" : "No"
+                %td= item.course.try(:schedulable?) ? "Yes" : "No"
                 %td
                   = add_remove_link @wishlist.map(&:course_id), item.course
                 %td


### PR DESCRIPTION
we should still investigate the root cause of this: people not going
through the autocomplete dropdown to add things to their wishlist
(whether by accident or their own malicious designs).