### PR TITLE
link professor names to searches for their courses

### DIFF
--- a/app/helpers/professors_helper.rb
+++ b/app/helpers/professors_helper.rb
@@ -1,0 +1,5 @@
+module ProfessorsHelper
+  def professor_search_link(professor)
+    link_to professor.name, courses_path(professor: professor.name)
+  end
+end

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -5,7 +5,7 @@
       .panel-heading{style: "background-color:#555;color:#eee;"}
       .panel-body
         .well
-          %h3= first_professor.name
+          %h3= professor_search_link(first_professor)
         %hr/
         %h3 Previous Semesters
         - @instances_by_semester.each do |semester, instances|
@@ -13,7 +13,7 @@
             %b= semester
             \:
           - instances.sort_by(&:section).each do |instance|
-            Section #{instance.section} taught by #{instance.professor.name}
+            Section #{instance.section} taught by #{professor_search_link(instance.professor)}
             %br
             = instance.schedule
             %br

--- a/spec/helpers/professors_helper_spec.rb
+++ b/spec/helpers/professors_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ProfessorsHelper, type: :helper do
+  describe '#professor_search_link' do
+    it 'should return a link to the course search for that professor' do
+      professor = double(name: 'foo')
+      result = '<a href="/courses?professor=foo">foo</a>'
+      expect(helper.professor_search_link(professor)).to eq result
+    end
+  end
+end


### PR DESCRIPTION
closes #86. @bhc24 I touched the HTML.

open to feedback on whether we should link to searches for every professor name on the page (currently doing this), or only for the main professor, or only on the individual sections, etc.