### PR TITLE
possible scoring implementation for course queries

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -81,7 +81,7 @@ class CoursesController < ApplicationController
   end
 
   def autocomplete
-    @courses = Course.search(params[:term])
+    @courses = Course.search(params[:term]).sort_by { |c| -c.score(params[:term]) }
     respond_to do |format|
       format.json do
         render json: @courses.map { |c| { id: c.id, label: c.long_string, value: c.to_param } }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -25,6 +25,10 @@ class Course < ActiveRecord::Base
     course_instances.any? { |course_instance| course_instance.try(:schedulable?) }
   end
 
+  def score(query)
+    ("#{self} #{title}".downcase.split & query.downcase.split).length
+  end
+
   def to_param
     "#{department}#{course_number}"
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -33,6 +33,32 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe '#score' do
+    let(:course) do
+      FactoryGirl.build(:course, department: 'EECS', course_number: 132, title: 'Intro to Java')
+    end
+
+    context 'with no word-level exact matches' do
+      it 'returns 0' do
+        expect(course.score('no match')).to eq 0
+      end
+
+      it 'returns 0' do
+        expect(course.score('jav')).to eq 0
+      end
+    end
+
+    context 'with some word-level matches' do
+      it 'returns the number of matches' do
+        expect(course.score('EECS Java')).to eq 2
+      end
+
+      it 'returns the number of matches even for "insignificant" words' do
+        expect(course.score('132 to')).to eq 2
+      end
+    end
+  end
+
   describe ".to_param" do
     it "should return a spaceless version of to_s" do
       expect(@course.to_param).to eq @course.to_s.gsub(' ', '')


### PR DESCRIPTION
This addresses #56 . I've got this working for the autocomplete, but not the general search. I haven't thought of a good way to handle the Tekin vs Gultekin problem brought up in the issue, though on second thought, I'm not sure it will be a problem, since this just defines a way to order courses based on a query.