### PR TITLE
The port needs fixing...

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,7 +6,7 @@ nodaemon=true
 
 [program:rails]
 environment = RAILS_ENV=production
-command = rails s -b 0.0.0.0
+command = rails s -b 0.0.0.0 -p 80
 autostart = true
 autorestart = true
 


### PR DESCRIPTION
We need to explicitly tell rails to start on port 80.  We're actually lucky it's working in production at all right now (it's starting with the wrong command, so it does start on port 80, but supervisor doesn't actually start).