### PR TITLE
Scheduler now allows users to plan for 2016

### DIFF
--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -14,9 +14,9 @@ class SchedulerController < ApplicationController
   # GET /scheduler
   # GET /scheduler.json
   def index
-      @planning_period_year = Semester.maximum('year')
-      @planning_period_semester = Semester.order(:year,
-                                                 semester: :desc).last.semester
+    @planning_period_year = Semester.maximum('year')
+    @planning_period_semester =
+      Semester.order(:year, semester: :desc).last.semester
   end
 
   # POST /scheduler.json

--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -14,6 +14,9 @@ class SchedulerController < ApplicationController
   # GET /scheduler
   # GET /scheduler.json
   def index
+      @planning_period_year = Semester.maximum('year')
+      @planning_period_semester = Semester.order(:year,
+                                                 semester: :desc).last.semester
   end
 
   # POST /scheduler.json

--- a/app/views/scheduler/index.html.haml
+++ b/app/views/scheduler/index.html.haml
@@ -9,10 +9,11 @@
           = text_field_tag :course_title, nil, placeholder: 'Add course instance', class: 'form-control'
 
         = form_for :semester, url: scheduler_path, method: :get, remote: true, html: {id: :semester_form} do |f|
-          = f.select :semester, 
-            options_for_select( %w(Fall Spring Summer).map { |str| [str, str.downcase] }, 
-                                @planning_period_semester.downcase)
-          = f.select :year, options_for_select(2008.. @planning_period_year, @planning_period_year)
+          = f.select :semester, options_for_select( |
+            %w(Fall Spring Summer).map {|str| [str, str.downcase]}, |
+            @planning_period_semester.downcase)
+          = f.select :year, options_for_select(2008.. @planning_period_year,
+                                                      @planning_period_year)
           = f.select :half, ['First Half', 'Second Half'].map { |str| [str, str.split.first.downcase] }
           = hidden_field_tag :old_feed, nil # this is the old feed we need to remove
           = f.submit 'Change Semester'

--- a/app/views/scheduler/index.html.haml
+++ b/app/views/scheduler/index.html.haml
@@ -9,8 +9,10 @@
           = text_field_tag :course_title, nil, placeholder: 'Add course instance', class: 'form-control'
 
         = form_for :semester, url: scheduler_path, method: :get, remote: true, html: {id: :semester_form} do |f|
-          = f.select :semester, %w(Fall Spring Summer).map { |str| [str, str.downcase] }
-          = f.select :year, options_for_select(2008..(DateTime.now+3.months).year, (DateTime.now + 3.months).year)
+          = f.select :semester, 
+            options_for_select( %w(Fall Spring Summer).map { |str| [str, str.downcase] }, 
+                                @planning_period_semester.downcase)
+          = f.select :year, options_for_select(2008.. @planning_period_year, @planning_period_year)
           = f.select :half, ['First Half', 'Second Half'].map { |str| [str, str.split.first.downcase] }
           = hidden_field_tag :old_feed, nil # this is the old feed we need to remove
           = f.submit 'Change Semester'

--- a/app/views/scheduler/index.html.haml
+++ b/app/views/scheduler/index.html.haml
@@ -9,11 +9,11 @@
           = text_field_tag :course_title, nil, placeholder: 'Add course instance', class: 'form-control'
 
         = form_for :semester, url: scheduler_path, method: :get, remote: true, html: {id: :semester_form} do |f|
-          = f.select :semester, options_for_select( |
-            %w(Fall Spring Summer).map {|str| [str, str.downcase]}, |
+          = f.select :semester,
+            options_for_select(%w(Fall Spring Summer).map {|str| [str, str.downcase]},
             @planning_period_semester.downcase)
-          = f.select :year, options_for_select(2008.. @planning_period_year,
-                                                      @planning_period_year)
+          = f.select :year, options_for_select(2008..@planning_period_year,
+                                                     @planning_period_year)
           = f.select :half, ['First Half', 'Second Half'].map { |str| [str, str.split.first.downcase] }
           = hidden_field_tag :old_feed, nil # this is the old feed we need to remove
           = f.submit 'Change Semester'

--- a/app/views/scheduler/index.html.haml
+++ b/app/views/scheduler/index.html.haml
@@ -10,7 +10,7 @@
 
         = form_for :semester, url: scheduler_path, method: :get, remote: true, html: {id: :semester_form} do |f|
           = f.select :semester, %w(Fall Spring Summer).map { |str| [str, str.downcase] }
-          = f.select :year, options_for_select(2008..DateTime.now.year, DateTime.now.year)
+          = f.select :year, options_for_select(2008..(DateTime.now+3.months).year, (DateTime.now + 3.months).year)
           = f.select :half, ['First Half', 'Second Half'].map { |str| [str, str.split.first.downcase] }
           = hidden_field_tag :old_feed, nil # this is the old feed we need to remove
           = f.submit 'Change Semester'


### PR DESCRIPTION
Scheduler now allows users to select the next year, starting in October (beforehand, users would have to wait for 2016 before scheduling for 2016). 

Caveat: My database isn't up to date, and therefore I was not able to test whether you can actually add 2016 classes. Other than that, though, neither I nor rake saw any regressions, and you can at least set 2016 in the view now :P

Signed-off-by: Koby Picker <kobzorz28@gmail.com>