### PR TITLE
Upgrades ruby to 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1-onbuild
+FROM ruby:2.4.0-onbuild
 
 MAINTAINER Matthew Bentley <matthew.t.bentley@gmail.com>
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.0
 
 MAINTAINER Andrew Mason <andrew@fixedpoint.xyz>
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '2.4.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails'


### PR DESCRIPTION
tests pass locally, though this does add a few more deprecation warnings from gems

after we merge this, i'll see if a `bundle update` makes those go away