### PR TITLE
Add a healthcheck to postgres

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,5 +14,3 @@ ADD Gemfile.lock /the_jolly_advisor/Gemfile.lock
 RUN bundle install --with test
 
 ADD . /the_jolly_advisor
-
-CMD RAILS_ENV=test rake db:test:prepare

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all:
 
 compose-build: Dockerfile.dev docker-compose.yaml
 	docker-compose up --build -d
+	docker-compose run test rake db:test:prepare
 
 compose-test: compose-build
 	docker-compose run test rake

--- a/Rakefile
+++ b/Rakefile
@@ -16,8 +16,8 @@ if ENV['IN_DOCKER']
   def connect_to_db
     begin
       ActiveRecord::Base.connection
-    rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad => e
-      puts e
+    rescue PG::ConnectionBad => e
+      puts "#{e.class}: #{e}"
       nil
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,29 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+if ENV['IN_DOCKER']
+  def wait_for_db_container
+    loop do
+      return if connect_to_db
+      sleep 1
+    end
+  end
+
+  def connect_to_db
+    begin
+      ActiveRecord::Base.connection
+    rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad => e
+      puts e
+      nil
+    end
+  end
+
+  task :wait_for_db => [:environment] do
+    wait_for_db_container
+  end
+
+  %w(spec test).each do |t|
+    Rake::Task["#{t}:prepare"].clear.enhance(%w(wait_for_db))
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -7,10 +7,11 @@ Rails.application.load_tasks
 
 if ENV['IN_DOCKER']
   def wait_for_db_container
-    loop do
+    3.times do
       return if connect_to_db
       sleep 1
     end
+    raise RuntimeError.new 'Could not establish connection to postgres in 3 attempts'
   end
 
   def connect_to_db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,5 +9,6 @@ services:
         environment:
             RAILS_ENV: test
             DB_HOST: db
+            IN_DOCKER: 1
         depends_on:
         - db


### PR DESCRIPTION
The relevant step is the test:prepare and spec:prepare tasks. We
"enhance" them (rake-speak) to do the custom wait_for_db task. This
depends on environment so that the database config is loaded.

Note that we only do this "enhancement" if we're in docker, which we
detect through the use of an environment variable which is set in the
compose file.