### PR TITLE
Push merged coverage data to Coveralls in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@ log/
 tmp/
 
 .{docker,git}ignore
-.{coveralls,codeclimate,hound,rubocop,travis}.yml
+.{codeclimate,hound,rubocop}.yml
 docker-compose.yaml
 
 {Docker,Guard,Make,Rake}file*

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: all compose-build compose-test
 
+CI ?= false
+TRAVIS ?=
+TRAVIS_JOB_ID ?=
+TRAVIS_PULL_REQUEST ?=
+
 all:
 
 compose-build: Dockerfile.dev docker-compose.yaml
@@ -7,5 +12,10 @@ compose-build: Dockerfile.dev docker-compose.yaml
 	docker-compose run test rake db:test:prepare
 
 compose-test: compose-build
-	docker-compose run test rake
+	docker-compose run \
+		-e CI=$(CI) \
+		-e TRAVIS=$(TRAVIS) \
+		-e TRAVIS_JOB_ID=$(TRAVIS_JOB_ID) \
+		-e TRAVIS_PULL_REQUEST=$(TRAVIS_PULL_REQUEST) \
+		test rake
 	docker-compose kill

--- a/Rakefile
+++ b/Rakefile
@@ -33,5 +33,5 @@ if ENV['IN_DOCKER']
 end
 
 if ENV['CI']
-  task :default => [:spec, :features, 'coveralls:push']
+  task :default => [:spec, :cucumber, 'coveralls:push']
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,3 +31,7 @@ if ENV['IN_DOCKER']
     Rake::Task["#{t}:prepare"].clear.enhance(%w(wait_for_db))
   end
 end
+
+if ENV['CI']
+  task :default => [:spec, :features, 'coveralls:push']
+end


### PR DESCRIPTION
Fixes #270.

Travis will always set [CI][travis_variables] for us, so we check that
environment variable to ensure we don't push local test coverage.

See [Coveralls docs][coveralls_docs] for where this Rakefile code came
from.

[travis_variables]: https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
[coveralls_docs]: http://docs.coveralls.io/ruby-on-rails#merging-multiple-test-suites