### PR TITLE
Consolidate routes using the `direct` feature

### DIFF
--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -22,18 +22,14 @@ the work on this project was done there, usually during trivia.
 <p>
 If you find a bug in the Jolly Advisor, please let us know so we can fix it
 for you. The best way to let us know about bugs is by
-<a href="https://github.com/hacsoc/the_jolly_advisor/issues/new">
-    submitting an issue on our GitHub
-</a>.
+<%= link_to 'submitting an issue on our GitHub', new_github_issue_url %>
 </p>
 
 <br>
 
 <p>
 Thought of an awesome feature?
-<a href="http://feathub.com/hacsoc/the_jolly_advisor">
-    Make a feature request
-</a>!
+<%= link_to 'Make a feature request', feathub_url %>!
 Has someone else already requested your feature? Give it a +1. We
 prioritize new features by how popular they are, so voting for your favorites
 is the best way to ensure they get added quickly.
@@ -43,10 +39,7 @@ is the best way to ensure they get added quickly.
 
 <p>
 Want to help out? We have a
-<a href="https://github.com/hacsoc/the_jolly_advisor/wiki/Contributing">
-    wiki page
-</a>
-to get you started.
+<%= link_to 'wiki page', github_contributing_wiki_url %> to get you started.
 </p>
 
 <h3>The Team</h3>

--- a/app/views/site/faq.html.erb
+++ b/app/views/site/faq.html.erb
@@ -11,9 +11,9 @@
                             <h4>Where can I find my degree requirements?</h4>
                         </div>
                         <div class="answer-body">
-                            The <%= link_to 'University Bulletin', 'http://bulletin.case.edu/' %>
+                            The <%= link_to 'University Bulletin', university_bulletin_url %>
                             is your legally binding list of requirements. You alone are
-                            <%= link_to 'responsible', 'http://case.edu/ugstudies/academic-policies/academic-regulations/' %>
+                            <%= link_to 'responsible', university_regulations_url %>
                             for making sure they are correct by the time of your graduation.
                             SIS is not guaranteed to be up-to-date or error-free.
                         </div>
@@ -41,7 +41,7 @@
                             Please keep in mind that if the change is in your favor, you may
                             need to fill out an advisement correction form. All Undergraduate
                             Studies forms are available in their office and online
-                            <%= link_to 'here', 'http://case.edu/ugstudies/forms/' %>.
+                            <%= link_to 'here', ugs_forms_url %>.
                         </div>
                     </div>
                 </div>
@@ -55,8 +55,7 @@
                             appropriate amount of time to respond. If emailing and showing
                             up to office hours aren't enough or if it's a time-sensitive
                             issue, you can always talk to your Undergraduate Studies Dean
-                            during
-                            <%= link_to 'Walk-In Hours', 'http://case.edu/ugstudies/walkin/' %>
+                            during <%= link_to 'Walk-In Hours', ugs_office_hours_url %>
                             for official business (major changes, hold releases, requirement
                             conflicts, etc.). Office hours change every week to make sure you
                             can find a time that doesn't conflict with your classes.
@@ -69,8 +68,7 @@
                             <h4>How do I know who my Dean is?</h4>
                         </div>
                         <div class="answer-body">
-                            You can check your Dean
-                            <%= link_to 'here', 'http://case.edu/ugstudies/about-us/who-we-are/' %>.
+                            You can check your Dean <%= link_to 'here', ugs_deans_url %>.
                         </div>
                     </div>
                 </div>
@@ -126,7 +124,7 @@
                             We do our best to keep information up-to-date. This is a
                             student-run site, so we can quickly respond to changes or
                             discrepancies. All you have to do is
-                            <%= link_to 'let us know', 'http://github.com/hacsoc/the_jolly_advisor/issues/new' %>
+                            <%= link_to 'let us know', new_github_issue_url %>
                             and we'll get it fixed as soon as possible.
                         </div>
                     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,15 @@ Rails.application.routes.draw do
   delete 'wishlist' => 'wishlist#remove_course'
   get 'faq' => 'site#faq'
   get 'about' => 'site#about'
+
+  direct(:university_bulletin) { 'http://bulletin.case.edu/' }
+  direct(:university_regulations) { 'http://case.edu/ugstudies/academic-policies/academic-regulations/' }
+  direct(:ugs_forms) { 'http://case.edu/ugstudies/forms/' }
+  direct(:ugs_office_hours) { 'http://case.edu/ugstudies/walkin/' }
+  direct(:ugs_deans) { 'http://case.edu/ugstudies/about-us/who-we-are/' }
+
+  direct(:new_github_issue) { 'https://github.com/hacsoc/the_jolly_advisor/issues/new' }
+  direct(:github_contributing_wiki) { 'https://github.com/hacsoc/the_jolly_advisor/wiki/Contributing' }
+
+  direct(:feathub) { 'https://feathub.com/hacsoc/the_jolly_advisor' }
 end


### PR DESCRIPTION
This was added in rails 5.1. The advantage here is that all our
hard-coded external URLs now live in a single place.

This will make doing #136 much easier, I think.