### PR TITLE
Fix NoMethodError in set_course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -38,6 +38,8 @@ class CoursesController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_course
     department, course_number = params[:id].match(/([a-zA-Z]+)(\d+)/).captures.map(&:upcase)
-    @course = Course.find_by(department: department, course_number: course_number) or not_found
+    @course = Course.find_by!(department: department, course_number: course_number)
+  rescue
+    not_found
   end
 end


### PR DESCRIPTION
The NoMethodError came from the regex match. If the regex failed to
match the course id, then `.captures` would be called on `nil`. So we
wrap the entire method in a `rescue` block that will result in a 404 if
any error occurs.

Then, to clean things up a bit more, use the `!` version of `find_by` so
that ActiveRecord raises an exception if no record is found. Now, all
error paths will hit the same `rescue`.