### PR TITLE
s/sanitize/connection.quote

### DIFF
--- a/config/initializers/patches/array.rb
+++ b/config/initializers/patches/array.rb
@@ -1,7 +1,7 @@
 module PGArrayPatch
   refine Array do
     def to_pg_sql
-      "{#{sort.map { |e| ActiveRecord::Base.sanitize(e) }.join(',')}}"
+      "{#{sort.map { |e| ActiveRecord::Base.connection.quote(e) }.join(',')}}"
     end
   end
 end


### PR DESCRIPTION
`sanitize` was never part of the Public API (apparently), and thus was
removed without warning in 5.1. The correct way is to use
`connection.quote`, as per [this
issue](https://github.com/rails/rails/issues/28947#issuecomment-310733481).

This fixes #280 